### PR TITLE
Docker Compose Build and Dependency Fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       context: .
       dockerfile: dockerfiles/base.dockerfile
     image: base:latest
+    pull_policy: build
     env_file:
       - .env
 
@@ -118,6 +119,8 @@ services:
   # Zenohd - distributed data exchange service
   zenohd:
     extends: x-package-base
+    image: zenohd:latest
+    pull_policy: build
     container_name: zenohd
     env_file:
       - .env
@@ -153,6 +156,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${TELEOP_PACKAGES}
+    image: teleop:latest
+    pull_policy: build
     container_name: teleop
     env_file:
       - .env
@@ -169,6 +174,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${CMD_MULTIPLEXER_PACKAGES}
+    image: cmd_multiplexer:latest
+    pull_policy: build
     container_name: cmd_multiplexer
     env_file:
       - .env
@@ -180,6 +187,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${CONTROL_PANEL_PACKAGES}
+    image: control_panel:latest
+    pull_policy: build
     container_name: control_panel
     env_file:
       - .env
@@ -195,6 +204,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${GAZEBO_PACKAGES}
+    image: gazebo:latest
+    pull_policy: build
     container_name: gazebo
     env_file:
       - .env
@@ -207,6 +218,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${GAZEBO_PACKAGES}
+    image: spawn_robot:latest
+    pull_policy: build
     container_name: spawn_robot
     env_file:
       - .env
@@ -261,6 +274,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${TF_PACKAGES}
+    image: global_tf:latest
+    pull_policy: build
     container_name: global_tf
     env_file:
       - .env
@@ -272,6 +287,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${TF_PACKAGES}
+    image: localization_pose:latest
+    pull_policy: build
     container_name: localization_pose
     env_file:
       - .env
@@ -327,6 +344,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${GROUND_TRUTH_PACKAGES}
+    image: ground_truth:latest
+    pull_policy: build
     container_name: ground_truth
     env_file:
       - .env
@@ -381,6 +400,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${EKF_PACKAGES}
+    image: ekf_localization:latest
+    pull_policy: build
     container_name: ekf_localization
     env_file:
       - .env
@@ -418,6 +439,8 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${WALLFOLLOWING_PACKAGES}
+    image: wallfollowing:latest
+    pull_policy: build
     container_name: wallfollowing
     env_file:
       - .env
@@ -432,6 +455,8 @@ services:
   # Development environment - interactive container for development
   development:
     extends: x-dev-base
+    image: development:latest
+    pull_policy: build
     container_name: development
     env_file:
       - .env
@@ -448,6 +473,8 @@ services:
     build:
       args:
         - INSTALL_PACKAGE_NAMES=${DEMO_PACKAGES}
+    image: talker:latest
+    pull_policy: build
     container_name: talker
     env_file:
       - .env
@@ -459,6 +486,8 @@ services:
     build:
       args:
         - INSTALL_PACKAGE_NAMES=${DEMO_PACKAGES}
+    image: listener:latest
+    pull_policy: build
     container_name: listener
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,8 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/base.dockerfile
-    image: base:latest
     env_file:
       - .env
-    profiles: ["base"]
 
   #==============================================================================
   # BASE SERVICE TEMPLATES
@@ -20,6 +18,8 @@ services:
 
   # Standard package base - for ROS packages without special requirements
   x-package-base:
+    depends_on:
+      - base
     build:
       context: .
       dockerfile: dockerfiles/package.dockerfile
@@ -37,6 +37,8 @@ services:
 
   # Physical car base - includes device access for hardware communication
   x-physical-base:
+    depends_on:
+      - base
     build:
       context: .
       dockerfile: dockerfiles/package.dockerfile
@@ -55,6 +57,8 @@ services:
 
   # GUI base - includes X11 forwarding for graphical applications
   x-gui-base:
+    depends_on:
+      - base
     build:
       context: .
       dockerfile: dockerfiles/package.dockerfile
@@ -78,6 +82,8 @@ services:
 
   # Development base - full workspace mount for development workflow
   x-dev-base:
+    depends_on:
+      - base
     build:
       context: .
       dockerfile: dockerfiles/development.dockerfile
@@ -111,7 +117,6 @@ services:
   # Zenohd - distributed data exchange service
   zenohd:
     extends: x-package-base
-    image: zenohd:latest
     container_name: zenohd
     env_file:
       - .env
@@ -147,7 +152,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${TELEOP_PACKAGES}
-    image: teleop:latest
     container_name: teleop
     env_file:
       - .env
@@ -164,7 +168,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${CMD_MULTIPLEXER_PACKAGES}
-    image: cmd_multiplexer:latest
     container_name: cmd_multiplexer
     env_file:
       - .env
@@ -176,7 +179,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${CONTROL_PANEL_PACKAGES}
-    image: control_panel:latest
     container_name: control_panel
     env_file:
       - .env
@@ -192,7 +194,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${GAZEBO_PACKAGES}
-    image: gazebo:latest
     container_name: gazebo
     env_file:
       - .env
@@ -205,7 +206,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${GAZEBO_PACKAGES}
-    image: spawn_robot:latest
     container_name: spawn_robot
     env_file:
       - .env
@@ -260,7 +260,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${TF_PACKAGES}
-    image: global_tf:latest
     container_name: global_tf
     env_file:
       - .env
@@ -272,7 +271,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${TF_PACKAGES}
-    image: localization_pose:latest
     container_name: localization_pose
     env_file:
       - .env
@@ -328,7 +326,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${GROUND_TRUTH_PACKAGES}
-    image: ground_truth:latest
     container_name: ground_truth
     env_file:
       - .env
@@ -383,7 +380,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${EKF_PACKAGES}
-    image: ekf_localization:latest
     container_name: ekf_localization
     env_file:
       - .env
@@ -421,7 +417,6 @@ services:
     build:
       args:
         - PACKAGE_NAMES=${WALLFOLLOWING_PACKAGES}
-    image: wallfollowing:latest
     container_name: wallfollowing
     env_file:
       - .env
@@ -436,7 +431,6 @@ services:
   # Development environment - interactive container for development
   development:
     extends: x-dev-base
-    image: development:latest
     container_name: development
     env_file:
       - .env
@@ -453,7 +447,6 @@ services:
     build:
       args:
         - INSTALL_PACKAGE_NAMES=${DEMO_PACKAGES}
-    image: talker:latest
     container_name: talker
     env_file:
       - .env
@@ -465,7 +458,6 @@ services:
     build:
       args:
         - INSTALL_PACKAGE_NAMES=${DEMO_PACKAGES}
-    image: listener:latest
     container_name: listener
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/base.dockerfile
+    image: base:latest
     env_file:
       - .env
 


### PR DESCRIPTION
# Docker Compose Build and Dependency Fixes

### Summary

This pull request resolves a series of cascading build and dependency issues within the Docker Compose setup. The primary problem was that services were attempting to pull base images from public registries instead of building them from the local source, leading to build failures and runtime errors. The fixes ensure that Docker Compose correctly builds images in the right order and uses the local Dockerfiles as the single source of truth.

### Detailed Breakdown of Changes

#### 1. The "No Manifest Found" Error

- **Problem:** When launching the dev container or other services, Docker Compose would fail with an error like `No manifest found for docker.io/library/base:latest`.
- **Root Cause:** The `development` service, and others that extend the abstract base templates (`x-package-base`, `x-gui-base`, etc.), depend on the `base:latest` image. However, the `docker-compose.yml` did not explicitly declare this dependency. As a result, Docker Compose would try to build a service without first building its foundational image, and would fall back to searching for it on Docker Hub, where it doesn't exist.
- **Solution:** A `depends_on: - base` directive was added to all the abstract base templates (`x-package-base`, `x-physical-base`, `x-gui-base`, and `x-dev-base`). This ensures that before any service is built, Docker Compose will first build the `base` service, making the `base:latest` image available locally.

  ```diff
  --- a/docker-compose.yml
  +++ b/docker-compose.yml
  @@ -21,6 +21,8 @@
   # Standard package base - for ROS packages without special requirements
   x-package-base:
  +  depends_on:
  +    - base
     build:
       context: .
       dockerfile: dockerfiles/package.dockerfile
  ```

  _(This change was applied to all `x-` base templates)_

#### 2. The "No Such Service: base" Error

- **Problem:** After adding `depends_on`, a new error appeared: `no such service: base`.
- **Root Cause:** The `base` service was assigned to a specific profile (`profiles: ["base"]`). When a command like `docker compose --profile sim up` was run, only the services in the `sim` profile were activated. Since the `base` profile was not active, Docker Compose could not find the `base` service to satisfy the dependency.
- **Solution:** The `profiles: ["base"]` line was removed from the `base` service definition. By not belonging to any specific profile, the `base` service is now always included and available whenever another service depends on it, regardless of which profiles are active.

  ```diff
  --- a/docker-compose.yml
  +++ b/docker-compose.yml
  @@ -10,5 +10,3 @@
     image: base:latest
     env_file:
       - .env
  -    profiles: ["base"]
  ```

#### 3. The "ros2: command not found" Runtime Error

- **Problem:** Once the build issues were resolved, services like `gazebo` would start but immediately fail with runtime errors such as `ros2: command not found`.
- **Root Cause:** Many services had both a `build` section and an `image` tag (e.g., `image: gazebo:latest`). This configuration creates a fallback mechanism: Docker Compose first tries to pull the specified image from a remote registry. If a public image with that name exists (which is true for `gazebo`), it gets pulled and used, completely ignoring the local `build` instructions. The public image did not have the required ROS 2 environment setup, causing the command to fail.
- **Solution:** The `image` tag was removed from all services that are intended to be built from local source code. This forces Docker Compose to always use the `build` section and the local Dockerfiles, which correctly set up the ROS 2 environment. The `base` service is the only one that retains its `image: base:latest` tag, which is essential for _naming_ the image so that other Dockerfiles can reference it via the `FROM base:latest` instruction.

  ```diff
  --- a/docker-compose.yml
  +++ b/docker-compose.yml
  @@ -200,7 +200,6 @@
     build:
       args:
         - PACKAGE_NAMES=${GAZEBO_PACKAGES}
  -  image: gazebo:latest
     container_name: gazebo
     env_file:
       - .env
  ```

  _(This change was applied to all services with a `build` section, except for `base`)_

These changes collectively make the Docker Compose setup more robust, predictable, and reliant on the local source code, resolving the chain of build and runtime errors.
